### PR TITLE
upgrading circe and jawn to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ There are two main modules, `akka-stream-json` and `akka-http-json`.
 
 ```
 libraryDependencies ++= List(
-  "org.mdedetrich" %% "akka-stream-json" % "0.2.0",
-  "org.mdedetrich" %% "akka-http-json" % "0.2.0"
+  "org.mdedetrich" %% "akka-stream-json" % "0.3.0",
+  "org.mdedetrich" %% "akka-http-json" % "0.3.0"
 )
 ```
 
-`akka-streams-json` depends on `jawn-parser` at version `0.13.0`
+`akka-streams-json` depends on `jawn-parser` at version `0.14.1`
 and is compiled against `akka-stream` at version `2.5.11`.
-The circe submodule depends on version `0.10.0` of `circe-jawn`
+The circe submodule depends on version `0.11.1` of `circe-jawn`
 The Akka Http submodule depends on version `10.1.5` of `akka-http`
 
 `akka-stream-json` is published for Scala 2.12 and 2.11.
@@ -70,12 +70,12 @@ over rendering, you'll only get an Unmarshaller.
 
 ```
 libraryDependencies ++= List(
-  "org.mdedetrich" %% "akka-stream-circe" % "0.2.0",
-  "org.mdedetrich" %% "akka-http-circe" % "0.2.0"
+  "org.mdedetrich" %% "akka-stream-circe" % "0.3.0",
+  "org.mdedetrich" %% "akka-http-circe" % "0.3.0"
 )
 ```
 
-(Using circe 0.10.0)
+(Using circe 0.11.1)
 
 Adding support for a specific framework is
 [quite](support/stream-circe/src/main/scala/org/mdedetrich/akka/stream/support/CirceStreamSupport.scala)

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ name := "akka-streams-json"
 
 val currentScalaVersion = "2.12.7"
 val scala211Version     = "2.11.12"
-val circeVersion        = "0.10.0"
+val circeVersion        = "0.11.1"
 val akkaVersion         = "2.5.17"
 val akkaHttpVersion     = "10.1.5"
-val jawnVersion         = "0.13.0"
+val jawnVersion         = "0.14.1"
 val scalaTestVersion    = "3.0.5"
 
 scalaVersion in ThisBuild := currentScalaVersion
@@ -16,7 +16,7 @@ lazy val streamJson = project.in(file("stream-json")) settings (
   name := "akka-stream-json",
   libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-    "org.spire-math"    %% "jawn-parser" % jawnVersion
+    "org.typelevel"     %% "jawn-parser" % jawnVersion
   )
 )
 

--- a/http-json/src/main/scala/org/mdedetrich/akka/http/JsonSupport.scala
+++ b/http-json/src/main/scala/org/mdedetrich/akka/http/JsonSupport.scala
@@ -4,8 +4,8 @@ import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import akka.http.scaladsl.util.FastFuture
-import jawn.RawFacade
 import org.mdedetrich.akka.json.stream.JsonStreamParser
+import org.typelevel.jawn.RawFacade
 
 trait JsonSupport {
 

--- a/stream-json/src/main/scala/org/mdedetrich/akka/json/stream/JsonStreamParser.scala
+++ b/stream-json/src/main/scala/org/mdedetrich/akka/json/stream/JsonStreamParser.scala
@@ -6,8 +6,8 @@ import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.stream._
 import akka.util.ByteString
-import jawn.AsyncParser.ValueStream
-import jawn._
+import org.typelevel.jawn.AsyncParser.ValueStream
+import org.typelevel.jawn._
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer

--- a/support/stream-circe/src/main/scala/org/mdedetrich/akka/stream/support/CirceStreamSupport.scala
+++ b/support/stream-circe/src/main/scala/org/mdedetrich/akka/stream/support/CirceStreamSupport.scala
@@ -7,8 +7,8 @@ import akka.util.ByteString
 import io.circe.CursorOp.DownField
 import io.circe.jawn.CirceSupportParser._
 import io.circe._
-import _root_.jawn.AsyncParser
 import org.mdedetrich.akka.json.stream.JsonStreamParser
+import org.typelevel.jawn.AsyncParser
 
 trait CirceStreamSupport {
 

--- a/tests/src/test/scala/org/mdedetrich/akka/http/JsonSupportSpec.scala
+++ b/tests/src/test/scala/org/mdedetrich/akka/http/JsonSupportSpec.scala
@@ -11,10 +11,10 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder, Printer}
-import jawn.ParseException
 import org.mdedetrich.akka.http.support.CirceHttpSupport
 import org.mdedetrich.akka.stream.support.CirceStreamSupport
 import org.scalatest._
+import org.typelevel.jawn.ParseException
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -210,7 +210,7 @@ class JsonSupportSpec
           Unmarshal(invalidEntity).to[Foo]
         }
         futureException.map {
-          _.getMessage should include("expected : got =")
+          _.getMessage should include("expected : got '=")
         }
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.3.0"


### PR DESCRIPTION
This PR upgrades the `circe` & `jawn` dependencies to the latest version.
Also, a bunch of import changes as `jawn` is now published under `typelevel`.