### PR TITLE
Scala 2.13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.idea/
+*.iml
 
 http-json/dist/*
 http-json/lib_managed/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.2.8


### PR DESCRIPTION
  - Updates library dependencies
  - Crossbuild for Scala 2.11, 2.12 and 2.13
  - For Scala 2.11 circe is version is 0.11.1, while for Scala 2.12 and 2.13 circe version is 0.12.1