### PR TITLE
Use ThisBuild for sbt-release settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,9 +119,9 @@ ThisBuild / pomIncludeRepository   := (_ => false)
 
 import ReleaseTransformations._
 
-releaseCrossBuild             := true
-releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
-releaseProcess := Seq[ReleaseStep](
+ThisBuild / releaseCrossBuild             := true
+ThisBuild / releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
+ThisBuild / releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,


### PR DESCRIPTION
Seem to be having issues with `publishSigned` not being used as part of release process