### PR TITLE
Manually use publishSigned

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,8 +119,7 @@ ThisBuild / pomIncludeRepository   := (_ => false)
 
 import ReleaseTransformations._
 
-releaseCrossBuild             := true
-releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
+releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -129,7 +128,7 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  releaseStepCommand("publishSigned"),
   setNextVersion,
   commitNextVersion,
   releaseStepCommand("sonatypeReleaseAll"),


### PR DESCRIPTION
It seems like the `publishArtifacts` command doesn't work properly in multi-module builds so instead we are manually using publishSigned